### PR TITLE
macaddrsetup: fix header include

### DIFF
--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <cutils/properties.h>
 


### PR DESCRIPTION
it is required for strcmp during karin build process

Signed-off-by: Humberto Borba <humberos@gmail.com>