### PR TITLE
macaddrsetup: fix log messages output

### DIFF
--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -6,6 +6,9 @@
 #include <unistd.h>
 #include <cutils/properties.h>
 
+#define LOG_TAG "macaddrsetup"
+#include <cutils/log.h>
+
 extern const char *__progname;
 extern int ta_open(uint8_t p, uint8_t m, uint8_t c);
 extern int ta_close(void);
@@ -21,13 +24,13 @@ int main(int argc, char **argv)
 	int ret, err, bt_addr, wl_addr;
 
 	property_get("ro.hardware",record,"");
-	fprintf(stderr, "Importing BT and WLAN address for %s platform\n", record);
+	SLOGI("Importing BT and WLAN address for %s platform\n", record);
 
 	if ((strcmp(record,"rhine")==0)||(strcmp(record,"shinano")==0)||(strcmp(record,"yukon")==0)||(strcmp(record,"kanuti")==0)||(strcmp(record,"kitakami")==0)){
 		wl_addr=2560;
 		bt_addr=2568;
 	} else {
-		fprintf(stderr, "Unsuported platform\n");
+		SLOGE("Unsupported platform\n");
 		exit(1);
 	}
 
@@ -36,27 +39,27 @@ int main(int argc, char **argv)
 		if (!err)
 			break;
 
-		fprintf(stderr, "failed to open misc ta: %d\n",err);
+		SLOGE("failed to open misc ta: %d\n",err);
 		sleep(5);
 	}
 
 	fpb = fopen("/data/etc/bluetooth_bdaddr", "w");
 	if (!fpb) {
-		fprintf(stderr, "failed to open /data/etc/bluetooth_bdaddr for writing:\n");
+		SLOGE("failed to open /data/etc/bluetooth_bdaddr for writing:\n");
 		ta_close();
 		exit(1);
 	}
 
 	fpw = fopen(argv[1], "w");
 	if (!fpw) {
-		fprintf(stderr, "failed to open %s for writing: %s\n", argv[1], strerror(errno));
+		SLOGE("failed to open %s for writing: %s\n", argv[1], strerror(errno));
 		ta_close();
 		exit(1);
 	}
 
 	err = ta_getsize(bt_addr, &size);
 	if (size != 6) {
-		fprintf(stderr, "BT mac address have wrong size (%d) in miscta", size);
+		SLOGE("BT mac address have wrong size (%d) in miscta", size);
 		ta_close();
 		fclose(fpb);
 		exit(1);
@@ -64,7 +67,7 @@ int main(int argc, char **argv)
 
 	err = ta_read(bt_addr, buf, size);
 	if (err) {
-		fprintf(stderr, "failed to read BT mac address from miscta");
+		SLOGE("failed to read BT mac address from miscta");
 		ta_close();
 		fclose(fpb);
 		exit(1);
@@ -72,7 +75,7 @@ int main(int argc, char **argv)
 
 	ret = fprintf(fpb, "%02x:%02x:%02x:%02x:%02x:%02x\n", buf[5], buf[4], buf[3], buf[2], buf[1], buf[0]);
 	if (ret != 18) {
-		fprintf(stderr, "failed to write BT mac address\n");
+		SLOGE("failed to write BT mac address\n");
 		ta_close();
 		fclose(fpb);
 		exit(1);
@@ -80,7 +83,7 @@ int main(int argc, char **argv)
 
 	err = ta_getsize(wl_addr, &size);
 	if (size != 6) {
-		fprintf(stderr, "mac address have wrong size (%d) in miscta", size);
+		SLOGE("mac address have wrong size (%d) in miscta", size);
 		ta_close();
 		fclose(fpw);
 		exit(1);
@@ -88,7 +91,7 @@ int main(int argc, char **argv)
 
 	err = ta_read(wl_addr, buf, size);
 	if (err) {
-		fprintf(stderr, "failed to read mac address from miscta");
+		SLOGE("failed to read mac address from miscta");
 		ta_close();
 		fclose(fpw);
 		exit(1);
@@ -96,7 +99,7 @@ int main(int argc, char **argv)
 
 	ret = fprintf(fpw, "%02x:%02x:%02x:%02x:%02x:%02x\n", buf[5], buf[4], buf[3], buf[2], buf[1], buf[0]);
 	if (ret != 18) {
-		fprintf(stderr, "failed to write WLAN mac address\n");
+		SLOGE("failed to write WLAN mac address\n");
 		ta_close();
 		fclose(fpw);
 		exit(1);


### PR DESCRIPTION
Use Android log api to make sure log messages are not lost when
macaddrsetup is called by init process.

Signed-off-by: Julien Bolard <jbolard@genymobile.com>