### PR TITLE
sony: macaddrsetup: Restrict the project to Sony AOSP devices only

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifneq ($(filter yukon rhine shinano kanuti kitakami loire tone,$(PRODUCT_PLATFORM)),)
+
 LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
@@ -14,3 +16,5 @@ LOCAL_MODULE := macaddrsetup
 LOCAL_MODULE_TAGS := optional
 
 include $(BUILD_EXECUTABLE)
+
+endif


### PR DESCRIPTION
* Avoid including macaddrsetup into a different device
   built inside the same build tree as Sony AOSP

Change-Id: Id15ee12bfcaf49425e90feaf06c128bbbcb8c822