### PR TITLE
macaddrsetup: move to vendor

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,6 +13,10 @@ LOCAL_SHARED_LIBRARIES := \
     libcutils
 
 LOCAL_MODULE := macaddrsetup
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 25 ))" )))
+LOCAL_MODULE_OWNER := sony
+LOCAL_PROPRIETARY_MODULE := true
+endif
 LOCAL_MODULE_TAGS := optional
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
system for aosp stuff
vendor for OSS stuff
odm for prebuilt libs provided by OEM

make sure it will be used since api level 25 n-mr1

Signed-off-by: David Viteri <davidteri91@gmail.com>