### PR TITLE
Fixes for creating MAC address files on Oreo

### DIFF
--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -109,8 +109,8 @@ int main(int argc, char **argv)
 			exit(1);
 		}
 
-		ret = fprintf(fpw, "%02x:%02x:%02x:%02x:%02x:%02x\n", buf[5], buf[4], buf[3], buf[2], buf[1], buf[0]);
-		if (ret != 18) {
+		ret = fprintf(fpw, "Intf0MacAddress=%02X%02X%02X%02X%02X%02X\nEND\n", buf[5], buf[4], buf[3], buf[2], buf[1], buf[0]);
+		if (ret != 33) {
 			SLOGE("failed to write WLAN mac address\n");
 			ta_close();
 			fclose(fpw);

--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <cutils/properties.h>
 #include <private/android_filesystem_config.h>
 
@@ -23,6 +24,7 @@ int main(int argc, char **argv)
 	uint32_t size;
 	char buf[6];
 	FILE *fpb, *fpw = NULL;
+	mode_t orig_mask;
 	int ret, err, bt_addr, wl_addr;
 	void *ta_handle = NULL;
 	int (*ta_open)(uint8_t p, uint8_t m, uint8_t c) = NULL;
@@ -54,7 +56,10 @@ int main(int argc, char **argv)
 		sleep(5);
 	}
 
+	// This file needs to be readable by the bluetooth group
+	orig_mask = umask(S_IWGRP | S_IROTH | S_IWOTH);
 	fpb = fopen(BT_MAC_FILE, "w");
+	umask(orig_mask);
 	if (!fpb) {
 		SLOGE("failed to open %s for writing\n", BT_MAC_FILE);
 		ta_close();


### PR DESCRIPTION
1. Fixes the permissions of the BT file so that the Bluetooth service can read it
2. Changes the format of the WLAN file to match what the kernel driver expects