### PR TITLE
Run macaddrsetup in the wifi group

### DIFF
--- a/vendor/etc/init/macaddrsetup.rc
+++ b/vendor/etc/init/macaddrsetup.rc
@@ -2,7 +2,7 @@
 service macaddrsetup /vendor/bin/macaddrsetup
     class core
     user system
-    group system bluetooth
+    group system bluetooth wifi
     disabled
     oneshot
 


### PR DESCRIPTION
In order to write the WLAN MAC address to /data/misc/wifi/wlan_mac.bin,
macaddrsetup needs to be in the wifi group. Without this file the wifi
interface won't come up with the correct MAC address.