### PR TITLE
macaddrsetup: allow macaddr write sys path dinamically

### DIFF
--- a/vendor/etc/init/macaddrsetup.rc
+++ b/vendor/etc/init/macaddrsetup.rc
@@ -1,5 +1,5 @@
 # OSS WLAN and BT MAC setup
-service macaddrsetup /vendor/bin/macaddrsetup
+service macaddrsetup /vendor/bin/macaddrsetup ${ro.wifi.addr_path}
     class core
     user system
     group system bluetooth
@@ -9,4 +9,3 @@ service macaddrsetup /vendor/bin/macaddrsetup
 on property:vold.post_fs_data_done=1
     # Generate Bluetooth MAC address file only when /data is ready
     start macaddrsetup
-


### PR DESCRIPTION
using sys.mac.path we can define it dinamically bettwen platforms since this service is used by all sony devices

Signed-off-by: David Viteri <davidteri91@gmail.com>