### PR TITLE
Clean up includes

### DIFF
--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -7,8 +7,6 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <cutils/properties.h>
-#include <private/android_filesystem_config.h>
 
 #define LOG_TAG "macaddrsetup"
 #include <cutils/log.h>


### PR DESCRIPTION
* Now project compiles with BOARD_VNDK_VERSION=current and without it.
* Test:
  m -j64 macaddrsetup
  BOARD_VNDK_VERSION=current m -j64 macaddrsetup

Change-Id: If289cb6b6301166b6ba05d2ea472d31fa85f4fdd