### PR TITLE
macaddrsetup: don't spam errors on warnings

### DIFF
--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -35,6 +35,7 @@ int main(int argc, char **argv)
 #ifdef BRCMFMAC
         struct ifreq ifr;
         int sockfd;
+        argv = NULL;
 #endif
 
         // Sony had a check for ro.hardware here, but since all supported devices were added here anyways,


### PR DESCRIPTION
it happens after brcmfmac #ifdefing

/macaddrsetup_intermediates/macaddrsetup.o hardware/sony/macaddrsetup/macaddrsetup.c"
hardware/sony/macaddrsetup/macaddrsetup.c:22:27: error: unused parameter 'argv' [-Werror,-Wunused-parameter]
int main(int argc, char **argv)

Change-Id: Ia8bb8700269564254f319988d285d4aeba370ce9
Signed-off-by: Humberto Borba <humberos@omnirom.org>