### PR TITLE
macaddrsetup: grant NET_ADMIN and NET_RAW

### DIFF
--- a/vendor/etc/init/macaddrsetup.rc
+++ b/vendor/etc/init/macaddrsetup.rc
@@ -3,5 +3,6 @@ service macaddrsetup /vendor/bin/macaddrsetup ${ro.wifi.addr_path}
     class main
     user system
     group system bluetooth wifi
+    capabilities NET_ADMIN NET_RAW
     oneshot
 


### PR DESCRIPTION
These capablities are required to be able to set the mac address in case brcmfmac is used.
With these capablities, the service is actually able to open the socket and write to it.