### PR TITLE
[master] macaddrsetup: Replace cutils/log.h with log/log.h

### DIFF
--- a/macaddrsetup.c
+++ b/macaddrsetup.c
@@ -9,7 +9,7 @@
 #include <sys/stat.h>
 
 #define LOG_TAG "macaddrsetup"
-#include <cutils/log.h>
+#include <log/log.h>
 
 #define LIB_TA "libta.so"
 


### PR DESCRIPTION
Use log.h from VNDK.

In file included from macaddrsetup.c:12:
system/core/libcutils/include_vndk/cutils/log.h:38:2: warning:
"Deprecated: don't include cutils/log.h, use either android/log.h or log/log.h" [-W#warnings]

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>