### PR TITLE
Move WiFi MAC path prop to vendor namespace

### DIFF
--- a/vendor/etc/init/macaddrsetup.rc
+++ b/vendor/etc/init/macaddrsetup.rc
@@ -2,7 +2,7 @@ on post-fs-data
     mkdir /data/vendor/wifi 0770 wifi wifi
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /vendor/bin/macaddrsetup ${ro.wifi.addr_path}
+service macaddrsetup /vendor/bin/macaddrsetup ${ro.vendor.wifi.addr_path}
     class main
     user system
     group system bluetooth wifi


### PR DESCRIPTION
* Ever since PRODUCT_COMPATIBLE_PROPERTY was introduced,
  vendor binaries are supposed to be using ro.vendor
  namespace props.