### PR TITLE
macaddrsetup: fix build on Android 7

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -29,7 +29,8 @@ LOCAL_MODULE_OWNER := sony
 LOCAL_INIT_RC      := vendor/etc/init/macaddrsetup.rc
 LOCAL_PROPRIETARY_MODULE := true
 else
-ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 25),)
+# Android 7's build system doesn't contain math_gt_or_eq.
+ifneq ($(filter $(PLATFORM_SDK_VERSION), 25 26 27 28),)
 LOCAL_MODULE_OWNER := sony
 LOCAL_INIT_RC      := vendor/etc/init/macaddrsetup_sdk25.rc
 LOCAL_PROPRIETARY_MODULE := true


### PR DESCRIPTION
Android 7's build system doesn't contain math_gt_or_eq, thus any
reference to it returns false. Replace the use of it with a simple
filter for API level 25 - 28.